### PR TITLE
feat(apple-oidc): support iOS AuthenticationServices Sign In with Apple flow

### DIFF
--- a/.changeset/swift-pears-matter.md
+++ b/.changeset/swift-pears-matter.md
@@ -1,0 +1,5 @@
+---
+"@aryalabs/openauth": minor
+---
+
+support iOS AuthenticationServices SIWA flow with Apple OIDC provider

--- a/packages/openauth/src/issuer.ts
+++ b/packages/openauth/src/issuer.ts
@@ -956,7 +956,7 @@ export function issuer<
 
       if (grantType === "client_credentials") {
         const provider = form.get("provider")?.toString(); 
-        if (!provider) 
+        if (!provider)
           return c.json({ error: "missing `provider` form value" }, 400)
         const match = input.providers[provider];
         if (!match) {

--- a/packages/openauth/src/provider/apple.ts
+++ b/packages/openauth/src/provider/apple.ts
@@ -35,6 +35,8 @@
 
 import { Oauth2Provider, Oauth2WrappedConfig } from "./oauth2.js"
 import { OidcProvider, OidcWrappedConfig } from "./oidc.js"
+import { createRemoteJWKSet, jwtVerify } from "jose"
+import { OauthError } from "../error.js"
 
 export interface AppleConfig extends Oauth2WrappedConfig {}
 export interface AppleOidcConfig extends OidcWrappedConfig {}
@@ -66,6 +68,7 @@ export function AppleProvider(config: AppleConfig) {
  * Create an Apple OIDC provider.
  *
  * This is useful if you just want to verify the user's email address.
+ * Includes support for client_credentials flow using Apple ID Token.
  *
  * @param config - The config for the provider.
  * @example
@@ -77,11 +80,64 @@ export function AppleProvider(config: AppleConfig) {
  * ```
  */
 export function AppleOidcProvider(config: AppleOidcConfig) {
-  return OidcProvider({
+  const baseProvider = OidcProvider({
     ...config,
     type: "apple" as const,
     issuer: "https://appleid.apple.com",
     responseType: "code",
     tokenEndpointAuthMethod: "client_secret_post",
   })
+
+  baseProvider.client = async ({ clientID, params }) => {
+    if (clientID !== config.clientID) {
+      throw new OauthError("unauthorized_client", "Client ID mismatch.")
+    }
+    if (!config.clientSecret) {
+      throw new OauthError("server_error", "Provider configuration missing clientSecret.")
+    }
+
+    const idToken = params.id_token
+    const appId = params.app_id
+
+    if (!idToken) {
+      throw new OauthError("invalid_request", "Missing required parameter: id_token")
+    }
+    if (!appId) {
+      throw new OauthError("invalid_request", "Missing required parameter: app_id")
+    }
+
+    try {
+      const jwksUrl = new URL(`https://appleid.apple.com/auth/keys`) as any
+      const jwks = createRemoteJWKSet(jwksUrl)
+
+      const { payload } = await jwtVerify(idToken, jwks, {
+        issuer: "https://appleid.apple.com",
+        audience: appId,
+      })
+
+      const email = payload.email as string
+      const isEmailVerified = payload.email_verified === true || String(payload.email_verified) === 'true'
+
+      if (!email) {
+        throw new OauthError("invalid_grant", "Email not found in Apple ID token. User might have used private relay without granting email access.")
+      }
+      if (!isEmailVerified) {
+        console.warn(`Apple email (${email}) is not verified. Proceeding, but verification recommended.`)
+      }
+
+      return {
+        id: {
+          email: email,
+          email_verified: isEmailVerified,
+          sub: payload.sub,
+        },
+        clientID: clientID
+      }
+
+    } catch (error: any) {
+      throw new OauthError("server_error", "Apple ID token verification failed.")
+    }
+  }
+
+  return baseProvider
 }

--- a/packages/openauth/src/provider/provider.ts
+++ b/packages/openauth/src/provider/provider.ts
@@ -8,7 +8,7 @@ export interface Provider<Properties = any> {
   init: (route: ProviderRoute, options: ProviderOptions<Properties>) => void
   client?: (input: {
     clientID: string
-    clientSecret: string
+    clientSecret?: string,
     params: Record<string, string>
   }) => Promise<Properties>
 }


### PR DESCRIPTION
branched from #3 which fixed issues in Apple OIDC provider

resolves #210 

adds support for direct integration with iOS/macOS [AuthenticationServices](https://developer.apple.com/documentation/authenticationservices/implementing-user-authentication-with-sign-in-with-apple) (Sign in with Apple) by updating the AppleOidcProvider to validate Apple ID tokens via the client_credentials grant type.

Previously, OpenAuth had no way to directly validate Apple ID tokens obtained from iOS apps using the native Sign in with Apple flow. This required app developers to either:
1. Implement a separate authentication service for iOS
2. Use a custom web view that disrupted the native iOS experience
3. Send tokens to a custom backend for validation


This PR extends the OpenAuth client_credentials grant type to handle Apple ID token verification, allowing iOS applications to authenticate directly with the OpenAuth server:
1. The iOS app obtains an ID token through Apple's ASAuthorizationAppleIDProvider
2. The app sends this token to OpenAuth's /token endpoint via client_credentials grant
3. OpenAuth validates the token against Apple's JWKS and returns OpenAuth access/refresh tokens
4. The iOS app uses these tokens like any other OpenAuth client
